### PR TITLE
Import test changes from JavaScriptCore (Debug)

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,5 +1,5 @@
 {
-  "targetRevisionAtLastExport": "f475b9e",
+  "targetRevisionAtLastExport": "18356c6",
   "sourceRevisionAtLastExport": "6c8213bb",
   "curatedFiles": {
     "/262-fully-curated-vendor-not-modified/array-flatten.js": "DELETED_IN_TARGET",


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore (Debug)

Changes imported in this pull request include all changes made since
[6c8213bb](https://github.com///github/blob/6c8213bb) in JavaScriptCore (Debug) and all changes made since [f475b9e](../blob/f475b9e) in
test262.

### 11 Ignored Files

These files were updated or added in the JavaScriptCore (Debug) repo but they
are not synced to test262 because they are excluded.

 - [implementation-contributed/javascriptcore/262-fully-curated-vendor-modified/array-indexof.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-fully-curated-vendor-modified/array-indexof.js)
 - [implementation-contributed/javascriptcore/262-fully-curated-vendor-rename/basic-weakmap-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-fully-curated-vendor-rename/basic-weakmap-post-rename.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-modified/duplicate-computed-accessors.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-partially-curated-vendor-modified/duplicate-computed-accessors.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-not-modified/empty-function.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-partially-curated-vendor-not-modified/empty-function.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-rename/function-toString-arrow-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-partially-curated-vendor-rename/function-toString-arrow-post-rename.js)
 - [implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_AND_NEW_SOURCE/generator-return.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_AND_NEW_SOURCE/generator-return.js)
 - [implementation-contributed/javascriptcore/RENAME_MODIFIED_TARGET_FILE_WITH_NOTE_ON_RENAME/import-basic-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/RENAME_MODIFIED_TARGET_FILE_WITH_NOTE_ON_RENAME/import-basic-post-rename.js)
 - [implementation-contributed/javascriptcore/RE_EXPORT_RENAMED_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/generator-yield-star-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/RE_EXPORT_RENAMED_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/generator-yield-star-post-rename.js)
 - [implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_NEW_EXTENSION_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION_AND_EXTENSION/has-custom-properties.jsx](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_NEW_EXTENSION_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION_AND_EXTENSION/has-custom-properties.jsx)
 - [implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/global-is-nan.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/global-is-nan.js)
 - [implementation-contributed/javascriptcore/UPDATE_EXTENSION_ON_MODIFIED_TARGET_FILE_WITH_NOTE_ON_EXTENSION_CHANGE/inferred-names.jsx](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/UPDATE_EXTENSION_ON_MODIFIED_TARGET_FILE_WITH_NOTE_ON_EXTENSION_CHANGE/inferred-names.jsx)
### 4 Files Classified as Fully Curated

These files will be ignored in future imports.

 - [implementation-contributed/javascriptcore/262-fully-curated-vendor-not-modified/array-flatten.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-fully-curated-vendor-not-modified/array-flatten.js)
 - [implementation-contributed/javascriptcore/262-only-modified-by-test262-auto-vendor-deleted/number-to-string.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-only-modified-by-test262-auto-vendor-deleted/number-to-string.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-deleted/date-negative-zero.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/262-partially-curated-vendor-deleted/date-negative-zero.js)
 - [implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_ON_SOURCE_DELETION/has-own-property-called-on-non-object.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531766097106/implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_ON_SOURCE_DELETION/has-own-property-called-on-non-object.js)