### PR TITLE
Import test changes from JavaScriptCore (Debug)

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -2,6 +2,9 @@
   "targetRevisionAtLastExport": "7940ece",
   "sourceRevisionAtLastExport": "6c8213bb",
   "curatedFiles": {
-    "/262-fully-curated-vendor-not-modified/array-flatten.js": "DELETED_IN_TARGET"
+    "/262-fully-curated-vendor-not-modified/array-flatten.js": "DELETED_IN_TARGET",
+    "/262-only-modified-by-test262-auto-vendor-deleted/number-to-string.js": "DELETED_IN_TARGET",
+    "/262-partially-curated-vendor-deleted/date-negative-zero.js": "DELETED_IN_TARGET",
+    "/APPEND_MODIFIED_TARGET_WITH_NOTE_ON_SOURCE_DELETION/has-own-property-called-on-non-object.js": "DELETED_IN_TARGET"
   }
 }

--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,5 +1,5 @@
 {
-  "targetRevisionAtLastExport": "7940ece",
+  "targetRevisionAtLastExport": "1aac5e5",
   "sourceRevisionAtLastExport": "6c8213bb",
   "curatedFiles": {
     "/262-fully-curated-vendor-not-modified/array-flatten.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/262-fully-curated-vendor-not-modified/array-flatten.js
+++ b/implementation-contributed/javascriptcore/262-fully-curated-vendor-not-modified/array-flatten.js
@@ -1,0 +1,108 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i) {
+        try {
+            if (Array.isArray(expected[i])) {
+                shouldBe(Array.isArray(actual[i]), true);
+                shouldBeArray(actual[i], expected[i]);
+            } else
+                shouldBe(actual[i], expected[i]);
+        } catch(e) {
+            print(JSON.stringify(actual));
+            throw e;
+        }
+    }
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldBe([].flat.length, 0);
+shouldBe([].flat.name, `flat`);
+
+shouldBeArray([].flat(), []);
+shouldBeArray([0, 1, 2, 3, , 4].flat(), [0, 1, 2, 3, 4]);
+shouldBeArray([,,,,,].flat(), []);
+
+shouldBeArray([].flat(0), []);
+shouldBeArray([0, 1, 2, 3, , 4].flat(0), [0, 1, 2, 3, 4]);
+shouldBeArray([,,,,,].flat(0), []);
+
+shouldBeArray([].flat(-1), []);
+shouldBeArray([0, 1, 2, 3, , 4].flat(-1), [0, 1, 2, 3, 4]);
+shouldBeArray([,,,,,].flat(-1), []);
+
+shouldBeArray([[],[]].flat(), []);
+shouldBeArray([[0],[1]].flat(), [0,1]);
+shouldBeArray([[0],[],1].flat(), [0,1]);
+shouldBeArray([[0],[[]],1].flat(), [0,[],1]);
+shouldBeArray([[0],[[]],1].flat(1), [0,[],1]);
+shouldBeArray([[0],[[]],1].flat(2), [0,1]);
+
+shouldBeArray([[],[]].flat(0), [[],[]]);
+shouldBeArray([[0],[1]].flat(0), [[0],[1]]);
+shouldBeArray([[0],[],1].flat(0), [[0],[],1]);
+shouldBeArray([[0],[[]],1].flat(0), [[0],[[]],1]);
+
+shouldBeArray([[[[[[[[[[[[[[[[[[[[[42]]]]]]]]]]]]]]]]]]]]].flat(Infinity), [42]);
+
+var array = [];
+shouldBe(array.flat() !== array, true);
+
+class DerivedArray extends Array { }
+shouldBe((new DerivedArray).flat() instanceof DerivedArray, true);
+var flat = [].flat;
+var realm = createGlobalObject();
+shouldBe(flat.call({}) instanceof Array, true);
+shouldBe(flat.call(new realm.Array) instanceof Array, true);
+var array2 = new realm.Array;
+array2.constructor = 0;
+
+shouldThrow(() => {
+    flat.call(array2);
+}, `TypeError: 0 is not a constructor`);
+
+var array2 = new realm.Array;
+array2.constructor = undefined;
+shouldBe(flat.call(array2) instanceof Array, true);
+
+var array2 = new realm.Array;
+array2.constructor = {
+    get [Symbol.species]() {
+        return null;
+    }
+};
+shouldBe(flat.call(array2) instanceof Array, true);
+
+var array2 = new realm.Array;
+array2.constructor = {
+    get [Symbol.species]() {
+        return undefined;
+    }
+};
+shouldBe(flat.call(array2) instanceof Array, true);
+
+var array2 = new realm.Array;
+array2.constructor = {
+    get [Symbol.species]() {
+        return DerivedArray;
+    }
+};
+shouldBe(flat.call(array2) instanceof DerivedArray, true);


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore (Debug)

Changes imported in this pull request include all changes made since
[6c8213bb](https://github.com///github/blob/6c8213bb) in JavaScriptCore (Debug) and all changes made since [7940ece](../blob/7940ece) in
test262.

### 11 Ignored Files

These files were updated or added in the JavaScriptCore (Debug) repo but they
are not synced to test262 because they are excluded.

 - [implementation-contributed/javascriptcore/262-fully-curated-vendor-modified/array-indexof.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-fully-curated-vendor-modified/array-indexof.js)
 - [implementation-contributed/javascriptcore/262-fully-curated-vendor-rename/basic-weakmap-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-fully-curated-vendor-rename/basic-weakmap-post-rename.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-modified/duplicate-computed-accessors.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-partially-curated-vendor-modified/duplicate-computed-accessors.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-not-modified/empty-function.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-partially-curated-vendor-not-modified/empty-function.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-rename/function-toString-arrow-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-partially-curated-vendor-rename/function-toString-arrow-post-rename.js)
 - [implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_AND_NEW_SOURCE/generator-return.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_AND_NEW_SOURCE/generator-return.js)
 - [implementation-contributed/javascriptcore/RENAME_MODIFIED_TARGET_FILE_WITH_NOTE_ON_RENAME/import-basic-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/RENAME_MODIFIED_TARGET_FILE_WITH_NOTE_ON_RENAME/import-basic-post-rename.js)
 - [implementation-contributed/javascriptcore/RE_EXPORT_RENAMED_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/generator-yield-star-post-rename.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/RE_EXPORT_RENAMED_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/generator-yield-star-post-rename.js)
 - [implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_NEW_EXTENSION_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION_AND_EXTENSION/has-custom-properties.jsx](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_NEW_EXTENSION_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION_AND_EXTENSION/has-custom-properties.jsx)
 - [implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/global-is-nan.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/RE_EXPORT_SOURCE_WITH_NOTE_ON_PREVIOUS_TARGET_DELETION/global-is-nan.js)
 - [implementation-contributed/javascriptcore/UPDATE_EXTENSION_ON_MODIFIED_TARGET_FILE_WITH_NOTE_ON_EXTENSION_CHANGE/inferred-names.jsx](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/UPDATE_EXTENSION_ON_MODIFIED_TARGET_FILE_WITH_NOTE_ON_EXTENSION_CHANGE/inferred-names.jsx)
### 3 Files Classified as Fully Curated

These files will be ignored in future imports.

 - [implementation-contributed/javascriptcore/262-only-modified-by-test262-auto-vendor-deleted/number-to-string.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-only-modified-by-test262-auto-vendor-deleted/number-to-string.js)
 - [implementation-contributed/javascriptcore/262-partially-curated-vendor-deleted/date-negative-zero.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-partially-curated-vendor-deleted/date-negative-zero.js)
 - [implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_ON_SOURCE_DELETION/has-own-property-called-on-non-object.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/APPEND_MODIFIED_TARGET_WITH_NOTE_ON_SOURCE_DELETION/has-own-property-called-on-non-object.js)










### 1 New File Added in JavaScriptCore (Debug)

These are new files added in JavaScriptCore (Debug) and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/262-fully-curated-vendor-not-modified/array-flatten.js](../blob/javascriptcore-debug-test262-debug-automation-export-1531770750086/implementation-contributed/javascriptcore/262-fully-curated-vendor-not-modified/array-flatten.js)